### PR TITLE
Correção exemplo dotnet

### DIFF
--- a/dotnet/README.md
+++ b/dotnet/README.md
@@ -11,4 +11,4 @@ Não é necessário instalar nenhum pacote!
 Digite o comando `dotnet run`
 
 ## Duração
-- 729 milissegundos
+- 1074 milissegundos


### PR DESCRIPTION
## Descrição
Correção do exemplo em dotnet, pois não estava aguardando o término da requisição HTTP.
O tempo calculado era apenas relacionado à leitura do arquivo txt.

## Alterações
- Reaproveitamento do HttpClient para manter a estabilidade da conexão
- Leitura mais eficiente do arquivo txt via stream
- Agrupamento e disparo das requisições para cada linha lida
- Aguardo do termino de todas as requisições http


## Antes

Não aguardava e printava a request depois de pritnar o tempo de execução
![image](https://user-images.githubusercontent.com/19656249/100820789-bfbded00-342d-11eb-9003-1aa7e8b3d18f.png)

## Agora

O tempo pode variar de acordo com o numero de nucleos e processos paralelos da maquina que está rodando.

![image](https://user-images.githubusercontent.com/19656249/100820826-d95f3480-342d-11eb-8bf7-1dc57ffa2f84.png)

